### PR TITLE
Added Endpoint for finding free rooms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+env
+**/__pycache__/

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import flask, json
-from flask import request, jsonify
+from flask import request, jsonify, abort
 from flask_cors import CORS
 from flask_compress import Compress
 from query import query
@@ -69,6 +69,16 @@ def api_room_sched():
         if required_arg not in args:
             return
     return jsonify(qe.get_room_classes(args["term"], args["room"]))
+
+@app.route("/api/all-rooms-open/", methods=['GET'])
+def api_all_avail_rooms():
+    # ensure good request
+    args = request.args
+    if not (args.keys() >= {"term","weekday","starttime","endtime"}):
+        return jsonify({"message":"provide all required query params!"}), 400
+    # Get all distinct classes
+    distinct_rooms = qe.get_avaliable_rooms(args["term"], args["weekday"], args["starttime"], args["endtime"])
+    return jsonify({"available_rooms": distinct_rooms }), 200
 
 Compress(app)
 if __name__ == "__main__":

--- a/query/query.py
+++ b/query/query.py
@@ -273,9 +273,10 @@ class QueryExecutor:
             if classLoc in conflicting_locations: continue
             # Check weekday match
             if classWeekday == weekday:
-                if starttime_as_min_int <= classEnd and classStart <= endtime_as_min_int: 
+                if starttime_as_min_int < classEnd and classStart < endtime_as_min_int: 
                     conflicting_locations.add(classLoc)
                     class_locations.pop(classLoc, None)
+                    continue
                 if endtime_as_min_int <= classStart:
                     class_locations[classLoc]["class_after"] = True
                 class_locations[classLoc]["classes_today"] += 1


### PR DESCRIPTION
Hey!

I've finished the backend for fetching all the free rooms given a timeframe, and I'm passing this on incase someone wants to work on the front-end.

Here is the usage:

![image](https://user-images.githubusercontent.com/38801683/223748344-1fed204c-7f35-4d9c-853b-632545fa2f19.png)

Here is a sample response (uploaded in .txt since .json isn't permitted, so just rename extension).
[sample_response.txt](https://github.com/Exanut/schedubuddy-server/files/10921855/sample_response.txt)

It is built to support this front-end implementation [HERE](https://github.com/Exanut/schedubuddy-web/issues/60)

- The "Class Scheduled After" filter corresponds to the attribute "class_after" in the json response.
- The "No Classes Scheduled Today" can be determined if the "classes_today" == 0

Let me know of any questions!